### PR TITLE
Improve performance of glearray.get() on Erlang

### DIFF
--- a/src/glearray.gleam
+++ b/src/glearray.gleam
@@ -86,6 +86,7 @@ pub fn length(of array: Array(a)) -> Int
 /// Error(Nil)
 /// ```
 ///
+@external(erlang, "glearray_ffi", "get")
 pub fn get(in array: Array(a), at index: Int) -> Result(a, Nil) {
   case is_valid_index(array, index) {
     True -> Ok(do_get(array, index))
@@ -93,7 +94,6 @@ pub fn get(in array: Array(a), at index: Int) -> Result(a, Nil) {
   }
 }
 
-@external(erlang, "glearray_ffi", "get")
 @external(javascript, "./glearray_ffi.mjs", "get")
 fn do_get(array: Array(a), index: Int) -> a
 

--- a/src/glearray_ffi.erl
+++ b/src/glearray_ffi.erl
@@ -4,7 +4,11 @@
 
 new() -> {}.
 
-get(Array, Index) -> element(Index + 1, Array).
+get(Array, Index) ->
+  case catch element(Index + 1, Array) of
+    {'EXIT', _} -> {error,nil};
+    E -> {ok,E}
+  end.
 
 set(Array, Index, Value) -> setelement(Index + 1, Array, Value).
 


### PR DESCRIPTION
Performance of `get()` can be improved dramatically on Erlang. For example this simple benchmark that calls the function a million times:

```gleam
import gleam/io
import gleam/list
import gleam/result
import glearray

pub fn main() {
  let a_thousand = list.range(0, 999)
  let array = a_thousand |> glearray.from_list
  let result =
    a_thousand
    |> list.fold(0, fn(sum, _) {
      sum
      + {
        a_thousand
        |> list.fold(0, fn(sum, j) {
          sum + { glearray.get(array, j) |> result.unwrap(0) }
        })
      }
    })
  io.debug(result)
}
```

The dominant runtime as profiled before this PR:
```
1> tprof:profile(bench, main, [], #{type => call_time}).
...
FUNCTION                              CALLS  TIME (μs)  PER CALL  [    %]
...
gleam@result:unwrap/2               1000000      87895      0.09  [10.71]
glearray_ffi:get/2                  1000000      89246      0.09  [10.87]
glearray:is_valid_index/2           1000000      90699      0.09  [11.05]
gleam@list:fold/3                   1002001     130833      0.13  [15.94]
bench:'-main/0-fun-0-'/3            1000000     194113      0.19  [23.65]
glearray:get/2                      1000000     221658      0.22  [27.00]
                                                820901            [100.0]
```

And after this PR:
```
1> tprof:profile(bench, main, [], #{type => call_time}).
...
FUNCTION                              CALLS  TIME (μs)  PER CALL  [    %]
...
gleam@result:unwrap/2               1000000      87571      0.09  [16.71]
glearray_ffi:get/2                  1000000      90305      0.09  [17.24]
gleam@list:fold/3                   1002001     130628      0.13  [24.93]
bench:'-main/0-fun-0-'/3            1000000     209170      0.21  [39.92]
                                                523922            [100.0]
```

Overall runtime of this example is reduced by 36%. Time taken per `get()` improves from 0.09 + 0.09 + 0.22 = 0.40ns to 0.09ns. Although the unavoidable cost of dealing with the `Result(a,Nil)` of at least 0.09ns should probably be included (so 0.49ns vs 0.18ns). Obviously the profiler affects performance somewhat but I've seen similar reduction in runtime of a real workload that does tens of millions of random array accesses.

I think similar improvements may be possible e.g. for `copy_set` which I'd be happy to look into but I wanted to keep this PR as small as possible initially. Also I have no Erlang experience so apologies for any atrocities I may have committed!