### PR TITLE
Add get_or_default to sidestep Result performance cost

### DIFF
--- a/src/glearray.gleam
+++ b/src/glearray.gleam
@@ -94,6 +94,35 @@ pub fn get(in array: Array(a), at index: Int) -> Result(a, Nil) {
   }
 }
 
+/// Returns the element at the specified index, starting from 0.
+///
+/// The specified default is returned if `index` is less than 0 or
+/// greater than / or equal to `length(array)`.
+///
+/// ## Performance
+///
+/// This function is very efficient and runs in constant time.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > from_list([5, 6, 7]) |> get_or_default(1, -1)
+/// 6
+/// ```
+///
+/// ```gleam
+/// > from_list([5, 6, 7]) |> get_or_default(3, -1)
+/// -1
+/// ```
+///
+@external(erlang, "glearray_ffi", "get_or_default")
+pub fn get_or_default(in array: Array(a), at index: Int, or default: a) -> a {
+  case is_valid_index(array, index) {
+    True -> do_get(array, index)
+    False -> default
+  }
+}
+
 @external(javascript, "./glearray_ffi.mjs", "get")
 fn do_get(array: Array(a), index: Int) -> a
 

--- a/src/glearray_ffi.erl
+++ b/src/glearray_ffi.erl
@@ -1,6 +1,6 @@
 -module(glearray_ffi).
 
--export([new/0, get/2, set/3, insert/3]).
+-export([new/0, get/2, get_or_default/3, set/3, insert/3]).
 
 new() -> {}.
 
@@ -8,6 +8,12 @@ get(Array, Index) ->
   case catch element(Index + 1, Array) of
     {'EXIT', _} -> {error,nil};
     E -> {ok,E}
+  end.
+
+get_or_default(Array, Index, Default) ->
+  case catch element(Index + 1, Array) of
+    {'EXIT', _} -> Default;
+    E -> E
   end.
 
 set(Array, Index, Value) -> setelement(Index + 1, Array, Value).

--- a/test/glearray_test.gleam
+++ b/test/glearray_test.gleam
@@ -47,6 +47,25 @@ pub fn get_test() {
   |> should.be_error
 }
 
+pub fn get_or_default_test() {
+  let list = [5, 4, 3, 2, 1]
+  let array = glearray.from_list(list)
+  list.index_map(list, fn(element, index) {
+    array
+    |> glearray.get_or_default(index, -1)
+    |> should.equal(element)
+  })
+
+  glearray.get_or_default(array, -1, -1)
+  |> should.equal(-1)
+  glearray.get_or_default(array, glearray.length(array), 42)
+  |> should.equal(42)
+  glearray.get_or_default(array, 100, -1)
+  |> should.equal(-1)
+  glearray.get_or_default(glearray.new(), 0, 0)
+  |> should.equal(0)
+}
+
 pub fn set_test() {
   let array = glearray.from_list([1, 2, 3, 4])
   let assert Ok(modified) = glearray.copy_set(in: array, at: 1, value: 10)


### PR DESCRIPTION
Follow up to #3. The same optimization does not work for JavaScript, but by avoiding the need for a `Result` we can get a 30-40x speed improvement. The improvement on Erlang is more modest at ~20% (although in many cases dealing with results will involve additional function calls so the real-world impact may be greater). Benchmarks were taken from `iv`, `get*` is the new function `get_or_default`:

# Node

```
gleam run --target js --runtime node --module bench
[...]
Input               Function                       IPS           Min           P99
glearray: 10        get 1k elements         12418.2363        0.0706        0.1672
glearray: 10        get* 1k elements       538737.6319        0.0016        0.0020
glearray: 100       get 1k elements         12160.1802        0.0711        0.1969
glearray: 100       get* 1k elements       520914.7312        0.0016        0.0021
glearray: 1000      get 1k elements         12177.6688        0.0689        0.2194
glearray: 1000      get* 1k elements       551761.4261        0.0016        0.0020
glearray: 10k       get 1k elements         12497.8230        0.0708        0.2420
glearray: 10k       get* 1k elements       492473.4962        0.0016        0.0020
glearray: 100k      get 1k elements         11375.4563        0.0693        0.2673
glearray: 100k      get* 1k elements       508169.6359        0.0017        0.0022
```

# Deno

```
gleam run --target js --runtime deno --module bench
[...]
Input               Function                       IPS           Min           P99
glearray: 10        get 1k elements         12027.6845        0.0738        0.1482
glearray: 10        get* 1k elements       363500.1849        0.0024        0.0036
glearray: 100       get 1k elements         11459.4256        0.0768        0.1166
glearray: 100       get* 1k elements       367760.8084        0.0024        0.0030
glearray: 1000      get 1k elements         12039.1011        0.0747        0.1144
glearray: 1000      get* 1k elements       363199.0251        0.0024        0.0036
glearray: 10k       get 1k elements         11330.5992        0.0822        0.1134
glearray: 10k       get* 1k elements       367020.3574        0.0024        0.0030
glearray: 100k      get 1k elements         11770.8695        0.0754        0.1116
glearray: 100k      get* 1k elements       368840.8112        0.0024        0.0030
```

# Erlang

```
gleam run --module bench
[...]
Input               Function                       IPS           Min           P99
glearray: 10        get 1k elements        136810.0937        0.0055        0.0105
glearray: 10        get* 1k elements       160678.4912        0.0051        0.0074
glearray: 100       get 1k elements        130111.0999        0.0055        0.0161
glearray: 100       get* 1k elements       159901.8906        0.0052        0.0075
glearray: 1000      get 1k elements        130741.7696        0.0057        0.0149
glearray: 1000      get* 1k elements       159324.8851        0.0052        0.0074
glearray: 10k       get 1k elements        132399.0631        0.0056        0.0137
glearray: 10k       get* 1k elements       155544.7791        0.0051        0.0076
glearray: 100k      get 1k elements        133604.7629        0.0058        0.0111
glearray: 100k      get* 1k elements       155871.4633        0.0053        0.0075
```