### PR TITLE
Improve performance of copy_set and copy_insert on Erlang

### DIFF
--- a/src/glearray.gleam
+++ b/src/glearray.gleam
@@ -120,6 +120,7 @@ fn do_get(array: Array(a), index: Int) -> a
 /// Error(Nil)
 /// ```
 ///
+@external(erlang, "glearray_ffi", "set")
 pub fn copy_set(
   in array: Array(a),
   at index: Int,
@@ -131,7 +132,6 @@ pub fn copy_set(
   }
 }
 
-@external(erlang, "glearray_ffi", "set")
 @external(javascript, "./glearray_ffi.mjs", "set")
 fn do_set(array: Array(a), index: Int, value: a) -> Array(a)
 
@@ -194,6 +194,7 @@ pub fn copy_push(onto array: Array(a), value value: a) -> Array(a)
 /// Error(Nil)
 /// ```
 ///
+@external(erlang, "glearray_ffi", "insert")
 pub fn copy_insert(
   into array: Array(a),
   at index: Int,
@@ -205,6 +206,5 @@ pub fn copy_insert(
   }
 }
 
-@external(erlang, "glearray_ffi", "insert")
 @external(javascript, "./glearray_ffi.mjs", "insert")
 fn do_insert(array: Array(a), index: Int, value: a) -> Array(a)

--- a/src/glearray_ffi.erl
+++ b/src/glearray_ffi.erl
@@ -10,6 +10,14 @@ get(Array, Index) ->
     E -> {ok,E}
   end.
 
-set(Array, Index, Value) -> setelement(Index + 1, Array, Value).
+set(Array, Index, Value) ->
+  case catch setelement(Index + 1, Array, Value) of
+    {'EXIT', _} -> {error,nil};
+    A -> {ok,A}
+  end.
 
-insert(Array, Index, Value) -> erlang:insert_element(Index + 1, Array, Value).
+insert(Array, Index, Value) ->
+  case catch erlang:insert_element(Index + 1, Array, Value) of
+    {'EXIT', _} -> {error,nil};
+    A -> {ok,A}
+  end.


### PR DESCRIPTION
Applying the same technique of #3 to `copy_set` and `copy_insert` yields a meaningful performance gain for small arrays:

# Before

```
Input               Function                       IPS           Min           P99
glearray: 10        set 1k elements         35282.8670        0.0239        0.0443
glearray: 100       set 1k elements         19480.9071        0.0388        0.1017
glearray: 1000      set 1k elements          2682.4007        0.3027        0.6363
glearray: 10k       set 1k elements           260.1347        3.5254        4.6076
glearray: 100k      set 1k elements            15.6756       60.7894       67.5147
```

# After

```
Input               Function                       IPS           Min           P99
glearray: 10        set 1k elements         45325.3542        0.0185        0.0269
glearray: 100       set 1k elements         22104.3305        0.0361        0.0528
glearray: 1000      set 1k elements          2908.2394        0.3104        0.3869
glearray: 10k       set 1k elements           250.4258        3.6005        4.7467
glearray: 100k      set 1k elements             4.7084      208.5569      222.2722
```

Performance for the 100k size was really erratic, I have also seen it on par with the "before" result. It just runs too slow to get any meaningful results at all.