### PR TITLE
Loosen version constraint to support stdlib v1

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,7 +7,7 @@ repository = { type = "github", user = "lunagl", repo = "glearray" }
 links = []
 
 [dependencies]
-gleam_stdlib = "~> 0.37"
+gleam_stdlib = ">= 0.37.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.3"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.37" }
+gleam_stdlib = { version = ">= 0.37.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.3" }

--- a/test/glearray_test.gleam
+++ b/test/glearray_test.gleam
@@ -95,7 +95,10 @@ pub fn push_test() {
 
   // Ensure immutability; relevant for the JS impl
   glearray.from_list([1, 2, 3])
-  |> function.tap(glearray.copy_push(_, 4))
+  |> fn(array) {
+    glearray.copy_push(array, 4)
+    array
+  }
   |> glearray.to_list
   |> should.equal([1, 2, 3])
 }


### PR DESCRIPTION
This PR loosens the version constraint on the stdlib to support stdlib v1.

Also had to fix one test to work with the new stdlib since `function.tap` was removed