### PR TITLE
Fix OTP catch deprecation warnings

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
 ]
 

--- a/src/glearray_ffi.erl
+++ b/src/glearray_ffi.erl
@@ -5,25 +5,29 @@
 new() -> {}.
 
 get(Array, Index) ->
-    case catch element(Index + 1, Array) of
-        {'EXIT', _} -> {error, nil};
+    try element(Index + 1, Array) of
         E -> {ok, E}
+    catch
+        error:badarg -> {error, nil}
     end.
 
 get_or_default(Array, Index, Default) ->
-    case catch element(Index + 1, Array) of
-        {'EXIT', _} -> Default;
+    try element(Index + 1, Array) of
         E -> E
+    catch
+        error:badarg -> Default
     end.
 
 set(Array, Index, Value) ->
-    case catch setelement(Index + 1, Array, Value) of
-        {'EXIT', _} -> {error, nil};
+    try setelement(Index + 1, Array, Value) of
         A -> {ok, A}
+    catch
+        error:badarg -> {error, nil}
     end.
 
 insert(Array, Index, Value) ->
-    case catch erlang:insert_element(Index + 1, Array, Value) of
-        {'EXIT', _} -> {error, nil};
+    try erlang:insert_element(Index + 1, Array, Value) of
         A -> {ok, A}
+    catch
+        error:badarg -> {error, nil}
     end.


### PR DESCRIPTION
OTP 29 is now out and includes some deprecation warnings I hit with glearray.

```
❯ gleam test
Downloading packages
 Downloaded 2 packages in 0.01s
  Compiling gleam_stdlib
  Compiling gleeunit
  Compiling glearray
/Users/jtdowney/code/glearray/build/dev/erlang/glearray/_gleam_artefacts/glearray_ffi.erl:8:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%    8|     case catch element(Index + 1, Array) of
%     |          ^

/Users/jtdowney/code/glearray/build/dev/erlang/glearray/_gleam_artefacts/glearray_ffi.erl:14:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   14|     case catch element(Index + 1, Array) of
%     |          ^

/Users/jtdowney/code/glearray/build/dev/erlang/glearray/_gleam_artefacts/glearray_ffi.erl:20:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   20|     case catch setelement(Index + 1, Array, Value) of
%     |          ^

/Users/jtdowney/code/glearray/build/dev/erlang/glearray/_gleam_artefacts/glearray_ffi.erl:26:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   26|     case catch erlang:insert_element(Index + 1, Array, Value) of
%     |          ^

   Compiled in 0.32s
    Running glearray_test.main
.......
7 passed, no failures
```